### PR TITLE
BUGFIX: Set missing dimensionConfiguration['default'] value

### DIFF
--- a/Classes/Service/ConfigurationContentDimensionPresetSource.php
+++ b/Classes/Service/ConfigurationContentDimensionPresetSource.php
@@ -73,6 +73,13 @@ class ConfigurationContentDimensionPresetSource extends NeosConfigurationContent
 
                     $dimensionConfiguration['defaultPreset'] = $newDefaultPreset;
 
+                    if (isset(
+                        $dimensionConfiguration['presets'][$newDefaultPreset],
+                        $dimensionConfiguration['presets'][$newDefaultPreset]['values']
+                    )) {
+                        $dimensionConfiguration['default'] = implode(',', $dimensionConfiguration['presets'][$newDefaultPreset]['values']);
+                    }
+
                     if ($this->forceEmptyUriSegment === true) {
                         $dimensionConfiguration['presets'][$newDefaultPreset]['uriSegment'] = '';
                     }


### PR DESCRIPTION
The 'default' value needs to be set too. If the value is not set, the Neos backend does not load the languages and Content Tree after the login.